### PR TITLE
drop Test::Most dependency

### DIFF
--- a/t/9000-bug-41738-merge-with-side-effects.t
+++ b/t/9000-bug-41738-merge-with-side-effects.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::Most;
+use Test::More;
 use Test::Deep;
 
 plan qw/no_plan/;


### PR DESCRIPTION
The test using Test::Most wasn't using any of its additional functions,
so it can be replaced with Test::More without any other changes.